### PR TITLE
Replace deprecated gcr.io registry with registry.k8s.io for kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manifests/manifest.yaml
+++ b/config/manifests/manifest.yaml
@@ -642,7 +642,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -651,10 +651,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1024Mi
+            memory: 128Mi
           requests:
             cpu: 5m
-            memory: 1024Mi
+            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary
- Migrate `kube-rbac-proxy` image from deprecated `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` to `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0`
- The `gcr.io` registry was shut down on March 18, 2025, causing `ImagePullBackOff` errors
- Regenerated manifest with `make generate-manifest`

## Test plan
- [ ] Deploy controller and verify kube-rbac-proxy container starts successfully
- [ ] Verify image pulls from `registry.k8s.io` without errors

Made with [Cursor](https://cursor.com)