### PR TITLE
Detect-and-heal meshnet new-node wiring race (AR-65093)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -55,6 +56,11 @@ func main() {
 	var maxConcurrentReconciles int
 	var kubeQPS float64
 	var kubeBurst int
+	healDefaults := controller.DefaultMeshnetHealConfig()
+	var meshnetHealEnabled bool
+	var meshnetHealGrace time.Duration
+	var meshnetHealMaxAttempts int
+	var meshnetHealBackoff time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8084", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8085", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
@@ -66,6 +72,14 @@ func main() {
 		"Maximum queries-per-second to the Kubernetes API server (client-side rate limit).")
 	flag.IntVar(&kubeBurst, "kube-api-burst", 200,
 		"Maximum burst for throttle to the Kubernetes API server.")
+	flag.BoolVar(&meshnetHealEnabled, "meshnet-heal-enabled", healDefaults.Enabled,
+		"Detect Cdnos pods that meshnet never wired (the new-node CNI race, AR-65093) and heal them by recreating the pod.")
+	flag.DurationVar(&meshnetHealGrace, "meshnet-heal-grace", healDefaults.GracePeriod,
+		"How long a pod must be Running-but-under-wired before meshnet detect-and-heal recreates it.")
+	flag.IntVar(&meshnetHealMaxAttempts, "meshnet-heal-max-attempts", healDefaults.MaxAttempts,
+		"Maximum number of times meshnet detect-and-heal recreates a single pod before giving up and emitting a Warning.")
+	flag.DurationVar(&meshnetHealBackoff, "meshnet-heal-backoff", healDefaults.Backoff,
+		"Minimum delay between successive meshnet detect-and-heal attempts on the same pod.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -97,7 +111,14 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		APIReader:               mgr.GetAPIReader(),
+		Recorder:                mgr.GetEventRecorderFor("cdnos-controller"),
 		MaxConcurrentReconciles: maxConcurrentReconciles,
+		MeshnetHeal: controller.MeshnetHealConfig{
+			Enabled:     meshnetHealEnabled,
+			GracePeriod: meshnetHealGrace,
+			MaxAttempts: meshnetHealMaxAttempts,
+			Backoff:     meshnetHealBackoff,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cdnos")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networkop.co.uk
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - networkop.co.uk
   resources:
   - topologies

--- a/internal/controller/cdnos_controller.go
+++ b/internal/controller/cdnos_controller.go
@@ -64,6 +64,7 @@ type CdnosReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networkop.co.uk,resources=topologies,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/cdnos_controller.go
+++ b/internal/controller/cdnos_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,9 +47,14 @@ type CdnosReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	APIReader client.Reader
+	// Recorder emits k8s Events (e.g. for meshnet detect-and-heal).
+	Recorder record.EventRecorder
 	// MaxConcurrentReconciles controls the number of concurrent reconciles.
 	// If <= 0, controller-runtime's default (1) is used.
 	MaxConcurrentReconciles int
+	// MeshnetHeal configures detect-and-heal for the meshnet new-node wiring
+	// race (AR-65093).
+	MeshnetHeal MeshnetHealConfig
 }
 
 //+kubebuilder:rbac:groups=cdnos.dev.drivenets.net,resources=cdnoss,verbs=get;list;watch;create;update;patch;delete
@@ -57,6 +63,7 @@ type CdnosReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods;services;secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networkop.co.uk,resources=topologies,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -131,9 +138,17 @@ func (r *CdnosReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
+	// Detect-and-heal the meshnet new-node wiring race (AR-65093): recreate a
+	// pod that meshnet never wired so its CNI ADD re-runs once meshnet is ready.
+	healResult, err := r.reconcileMeshnetHeal(ctx, cdnos, pod)
+	if err != nil {
+		log.Error(err, "unable to reconcile meshnet heal")
+		return ctrl.Result{}, err
+	}
+
 	log.V(1).Info("Cdnos reconciled", "Name", cdnos.Name, "Image", cdnos.Spec.Image, "Namespace", cdnos.Namespace)
 
-	return ctrl.Result{}, nil
+	return healResult, nil
 }
 
 // This is the function that is responsible for creating the tls secret

--- a/internal/controller/meshnet_heal.go
+++ b/internal/controller/meshnet_heal.go
@@ -169,13 +169,25 @@ func (r *CdnosReconciler) reconcileMeshnetHeal(ctx context.Context, cdnos *cdnos
 	log := log.FromContext(ctx)
 
 	// Re-read the pod from the cache so we observe the current truth: a pod
-	// that reconcilePod just created (Pending) or just deleted for a spec
-	// change (NotFound / terminating) must not be touched here.
+	// that reconcilePod just deleted for a spec change (NotFound / terminating)
+	// must not be touched here.
 	fresh := &corev1.Pod{}
 	if err := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, fresh); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if fresh.DeletionTimestamp != nil || fresh.Status.Phase != corev1.PodRunning {
+	// Skip terminating and terminal pods. We deliberately do NOT require
+	// PodRunning: KNE's init-wait init container holds an under-wired mcDNOS
+	// pod in Pending/Init indefinitely (it loops forever waiting for the
+	// missing interfaces), so it never reaches Running. Acting on Pending is
+	// safe because the under-wired signal is phase-independent: meshnet's CNI
+	// plugin stamps status.net_ns via SetAlive at CNI ADD (sandbox creation),
+	// before any init/main container runs - so a Pending pod with spec.links
+	// and an empty status.net_ns definitively means meshnet never ran (the
+	// race), not a pod that is merely still pulling/starting. The grace period
+	// and bounded-attempts/backoff guardrails below still apply unchanged.
+	if fresh.DeletionTimestamp != nil ||
+		fresh.Status.Phase == corev1.PodSucceeded ||
+		fresh.Status.Phase == corev1.PodFailed {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/meshnet_heal.go
+++ b/internal/controller/meshnet_heal.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2024 Drivenets
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	cdnosv1 "github.com/drivenets/cdnos-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Detect-and-heal for the meshnet new-node wiring race (AR-65093).
+//
+// On a freshly autoscaled node, a Cdnos/mcDNOS pod's CNI ADD can run before
+// meshnet's CNI conflist is installed/ready on that node. When that happens the
+// meshnet CNI plugin never runs for the pod, so the pod comes up with only the
+// base CNI interface (eth0) and is permanently missing its meshnet data
+// interfaces until it is recreated.
+//
+// Detection signal (low coupling, read-only): meshnet maintains a per-pod
+// Topology CR (networkop.co.uk/v1beta1, named after the pod). Its spec.links is
+// the authoritative set of interfaces meshnet must wire, and meshnet's CNI
+// plugin calls SetAlive - which stamps status.net_ns / status.src_ip - at the
+// very start of its ADD, before it traverses any link. Therefore an empty
+// status.net_ns on a pod whose Topology has spec.links means "meshnet never ran
+// for this pod", which is exactly the new-node race. A pod that is merely
+// waiting for slow peers still has net_ns set, so this signal does not
+// false-positive on normal wiring in progress.
+//
+// Heal: delete the under-wired pod. The normal reconcile path recreates it, so
+// its CNI ADD re-runs once meshnet is ready and meshnet wires it normally.
+
+const (
+	healAttemptsAnnotation    = "meshnet.heal.cdnos.dev.drivenets.net/attempts"
+	healLastAttemptAnnotation = "meshnet.heal.cdnos.dev.drivenets.net/last-attempt"
+	healCappedAnnotation      = "meshnet.heal.cdnos.dev.drivenets.net/capped"
+
+	healReasonRecreate = "MeshnetHealRecreate"
+	healReasonCapped   = "MeshnetHealCapped"
+)
+
+// topologyGVK is the GroupVersionKind of meshnet's per-pod Topology CR. We read
+// it as an unstructured object so the controller does not take a compile-time
+// dependency on the meshnet module.
+var topologyGVK = schema.GroupVersionKind{
+	Group:   "networkop.co.uk",
+	Version: "v1beta1",
+	Kind:    "Topology",
+}
+
+// MeshnetHealConfig configures the meshnet detect-and-heal behaviour. The
+// grace period, attempt cap, and backoff are the guardrails that keep a buggy
+// or mistargeted heal from mass-deleting pods.
+type MeshnetHealConfig struct {
+	// Enabled turns the whole feature on/off.
+	Enabled bool
+	// GracePeriod is how long a pod must have been Running-but-under-wired
+	// before we act, so we never race a pod that is still legitimately wiring.
+	GracePeriod time.Duration
+	// MaxAttempts bounds how many times we recreate a single pod before giving
+	// up and emitting a Warning instead of looping forever.
+	MaxAttempts int
+	// Backoff is the minimum delay between successive heal attempts on the same
+	// pod.
+	Backoff time.Duration
+}
+
+// DefaultMeshnetHealConfig returns the default configuration. The feature
+// defaults ON: the race leaves pods permanently stuck and requires manual
+// recreation, and the grace period + attempt cap + backoff make the automated
+// heal safe. Operators can disable it with --meshnet-heal-enabled=false.
+func DefaultMeshnetHealConfig() MeshnetHealConfig {
+	return MeshnetHealConfig{
+		Enabled:     true,
+		GracePeriod: 90 * time.Second,
+		MaxAttempts: 3,
+		Backoff:     60 * time.Second,
+	}
+}
+
+// healDecision is the action decideHeal selects for an under-wired pod.
+type healDecision int
+
+const (
+	// healWait means under-wired but still within the grace period or backoff;
+	// re-check later.
+	healWait healDecision = iota
+	// healAct means recreate the pod now.
+	healAct
+	// healCapped means the per-pod attempt cap is exhausted; warn and stop.
+	healCapped
+)
+
+// decideHeal is the pure decision core for an under-wired pod. It is split out
+// from the k8s plumbing so it can be unit-tested exhaustively.
+func decideHeal(now, runningSince, lastAttempt time.Time, attempts int, cfg MeshnetHealConfig) (healDecision, time.Duration) {
+	if age := now.Sub(runningSince); age < cfg.GracePeriod {
+		return healWait, cfg.GracePeriod - age
+	}
+	if attempts >= cfg.MaxAttempts {
+		return healCapped, 0
+	}
+	if !lastAttempt.IsZero() {
+		if since := now.Sub(lastAttempt); since < cfg.Backoff {
+			return healWait, cfg.Backoff - since
+		}
+	}
+	return healAct, 0
+}
+
+// meshnetWiring extracts, from a Topology CR, the number of links meshnet is
+// expected to wire and whether meshnet has marked the pod alive (i.e. its CNI
+// plugin ran). expected>0 && !wired is the AR-65093 under-wired signal.
+func meshnetWiring(topo *unstructured.Unstructured) (expected int, wired bool) {
+	links, _, _ := unstructured.NestedSlice(topo.Object, "spec", "links")
+	expected = len(links)
+	netNs, _, _ := unstructured.NestedString(topo.Object, "status", "net_ns")
+	srcIP, _, _ := unstructured.NestedString(topo.Object, "status", "src_ip")
+	wired = netNs != "" && srcIP != ""
+	return expected, wired
+}
+
+// podRunningSince returns the time the pod's sandbox started, used as the
+// anchor for the grace period.
+func podRunningSince(pod *corev1.Pod) time.Time {
+	if pod.Status.StartTime != nil {
+		return pod.Status.StartTime.Time
+	}
+	return pod.CreationTimestamp.Time
+}
+
+// reconcileMeshnetHeal detects a Cdnos/mcDNOS pod that meshnet never wired
+// (the new-node race) and heals it by recreating it. It is safe to call on
+// every reconcile: it no-ops for non-meshnet pods, pods still within the grace
+// period, healthy (wired) pods, and pods that have exhausted their attempt cap.
+//
+// Concurrency: controller-runtime serializes reconciles per Cdnos key, so the
+// read-modify-write of the heal-accounting annotations on this Cdnos is safe
+// without extra locking.
+func (r *CdnosReconciler) reconcileMeshnetHeal(ctx context.Context, cdnos *cdnosv1.Cdnos, pod *corev1.Pod) (ctrl.Result, error) {
+	if !r.MeshnetHeal.Enabled || pod == nil {
+		return ctrl.Result{}, nil
+	}
+	log := log.FromContext(ctx)
+
+	// Re-read the pod from the cache so we observe the current truth: a pod
+	// that reconcilePod just created (Pending) or just deleted for a spec
+	// change (NotFound / terminating) must not be touched here.
+	fresh := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, fresh); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if fresh.DeletionTimestamp != nil || fresh.Status.Phase != corev1.PodRunning {
+		return ctrl.Result{}, nil
+	}
+
+	// Read the per-pod Topology CR directly from the API server (uncached: we
+	// do not watch the meshnet CRD). NotFound means this is not a meshnet pod.
+	topo := &unstructured.Unstructured{}
+	topo.SetGroupVersionKind(topologyGVK)
+	if err := r.APIReader.Get(ctx, types.NamespacedName{Name: fresh.Name, Namespace: fresh.Namespace}, topo); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	expected, wired := meshnetWiring(topo)
+	if expected == 0 {
+		return ctrl.Result{}, nil
+	}
+	if wired {
+		// Healthy: clear any heal accounting so a future race on this Cdnos
+		// starts with a fresh budget.
+		return ctrl.Result{}, r.clearHealState(ctx, cdnos)
+	}
+
+	// Under-wired: meshnet never ran for this pod incarnation.
+	now := time.Now()
+	attempts, lastAttempt := readHealState(cdnos)
+	decision, wait := decideHeal(now, podRunningSince(fresh), lastAttempt, attempts, r.MeshnetHeal)
+
+	switch decision {
+	case healWait:
+		return ctrl.Result{RequeueAfter: wait}, nil
+
+	case healCapped:
+		if cdnos.Annotations[healCappedAnnotation] != "true" {
+			msg := fmt.Sprintf("meshnet under-wired pod %s/%s not healed: 0/%d interfaces wired after %d attempts; manual intervention required",
+				fresh.Namespace, fresh.Name, expected, attempts)
+			log.Info(msg)
+			r.event(cdnos, corev1.EventTypeWarning, healReasonCapped, msg)
+			if err := r.patchHealAnnotations(ctx, cdnos, map[string]string{healCappedAnnotation: "true"}); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+
+	case healAct:
+		// Record the attempt BEFORE deleting so a crash between delete and the
+		// next reconcile cannot drive an unbounded recreate loop.
+		if err := r.patchHealAnnotations(ctx, cdnos, map[string]string{
+			healAttemptsAnnotation:    strconv.Itoa(attempts + 1),
+			healLastAttemptAnnotation: now.UTC().Format(time.RFC3339),
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		msg := fmt.Sprintf("recreating under-wired Cdnos pod %s/%s: 0/%d meshnet interfaces wired (attempt %d/%d)",
+			fresh.Namespace, fresh.Name, expected, attempts+1, r.MeshnetHeal.MaxAttempts)
+		log.Info(msg)
+		r.event(cdnos, corev1.EventTypeNormal, healReasonRecreate, msg)
+		if err := r.Delete(ctx, fresh, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		// Re-check after the grace period to confirm the recreated pod wired.
+		return ctrl.Result{RequeueAfter: r.MeshnetHeal.GracePeriod}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// readHealState reads the per-Cdnos heal accounting from annotations.
+func readHealState(cdnos *cdnosv1.Cdnos) (attempts int, lastAttempt time.Time) {
+	if cdnos.Annotations == nil {
+		return 0, time.Time{}
+	}
+	attempts, _ = strconv.Atoi(cdnos.Annotations[healAttemptsAnnotation])
+	if v := cdnos.Annotations[healLastAttemptAnnotation]; v != "" {
+		lastAttempt, _ = time.Parse(time.RFC3339, v)
+	}
+	return attempts, lastAttempt
+}
+
+// patchHealAnnotations merges the given annotations onto the Cdnos.
+func (r *CdnosReconciler) patchHealAnnotations(ctx context.Context, cdnos *cdnosv1.Cdnos, kv map[string]string) error {
+	patch := client.MergeFrom(cdnos.DeepCopy())
+	if cdnos.Annotations == nil {
+		cdnos.Annotations = map[string]string{}
+	}
+	for k, v := range kv {
+		cdnos.Annotations[k] = v
+	}
+	return r.Patch(ctx, cdnos, patch)
+}
+
+// clearHealState removes all heal-accounting annotations if any are present.
+func (r *CdnosReconciler) clearHealState(ctx context.Context, cdnos *cdnosv1.Cdnos) error {
+	if cdnos.Annotations == nil {
+		return nil
+	}
+	_, hasAttempts := cdnos.Annotations[healAttemptsAnnotation]
+	_, hasLast := cdnos.Annotations[healLastAttemptAnnotation]
+	_, hasCapped := cdnos.Annotations[healCappedAnnotation]
+	if !hasAttempts && !hasLast && !hasCapped {
+		return nil
+	}
+	patch := client.MergeFrom(cdnos.DeepCopy())
+	delete(cdnos.Annotations, healAttemptsAnnotation)
+	delete(cdnos.Annotations, healLastAttemptAnnotation)
+	delete(cdnos.Annotations, healCappedAnnotation)
+	return r.Patch(ctx, cdnos, patch)
+}
+
+// event records a k8s Event on the Cdnos if a recorder is configured.
+func (r *CdnosReconciler) event(cdnos *cdnosv1.Cdnos, eventType, reason, msg string) {
+	if r.Recorder != nil {
+		r.Recorder.Event(cdnos, eventType, reason, msg)
+	}
+}

--- a/internal/controller/meshnet_heal_test.go
+++ b/internal/controller/meshnet_heal_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2024 Drivenets
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	cdnosv1 "github.com/drivenets/cdnos-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMeshnetWiring(t *testing.T) {
+	tests := []struct {
+		name         string
+		links        []interface{}
+		netNs        string
+		srcIP        string
+		wantExpected int
+		wantWired    bool
+	}{
+		{
+			name:         "no links is not a meshnet pod",
+			links:        nil,
+			wantExpected: 0,
+			wantWired:    false,
+		},
+		{
+			name:         "links but never wired (the race)",
+			links:        []interface{}{map[string]interface{}{"local_intf": "eth1"}, map[string]interface{}{"local_intf": "eth2"}},
+			netNs:        "",
+			srcIP:        "",
+			wantExpected: 2,
+			wantWired:    false,
+		},
+		{
+			name:         "links and wired",
+			links:        []interface{}{map[string]interface{}{"local_intf": "eth1"}},
+			netNs:        "/proc/123/ns/net",
+			srcIP:        "10.0.0.1",
+			wantExpected: 1,
+			wantWired:    true,
+		},
+		{
+			name:         "net_ns set but src_ip empty is not wired",
+			links:        []interface{}{map[string]interface{}{"local_intf": "eth1"}},
+			netNs:        "/proc/123/ns/net",
+			srcIP:        "",
+			wantExpected: 1,
+			wantWired:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			topo := newTopology("r0", "ns", tc.links, tc.netNs, tc.srcIP)
+			expected, wired := meshnetWiring(topo)
+			if expected != tc.wantExpected {
+				t.Errorf("expected=%d, want %d", expected, tc.wantExpected)
+			}
+			if wired != tc.wantWired {
+				t.Errorf("wired=%v, want %v", wired, tc.wantWired)
+			}
+		})
+	}
+}
+
+func TestDecideHeal(t *testing.T) {
+	cfg := MeshnetHealConfig{Enabled: true, GracePeriod: 90 * time.Second, MaxAttempts: 3, Backoff: 60 * time.Second}
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		runningSince time.Time
+		lastAttempt  time.Time
+		attempts     int
+		wantDecision healDecision
+	}{
+		{
+			name:         "within grace period -> wait",
+			runningSince: now.Add(-30 * time.Second),
+			attempts:     0,
+			wantDecision: healWait,
+		},
+		{
+			name:         "past grace, first attempt -> act",
+			runningSince: now.Add(-5 * time.Minute),
+			attempts:     0,
+			wantDecision: healAct,
+		},
+		{
+			name:         "past grace but within backoff -> wait",
+			runningSince: now.Add(-5 * time.Minute),
+			lastAttempt:  now.Add(-10 * time.Second),
+			attempts:     1,
+			wantDecision: healWait,
+		},
+		{
+			name:         "past grace, backoff elapsed -> act",
+			runningSince: now.Add(-5 * time.Minute),
+			lastAttempt:  now.Add(-2 * time.Minute),
+			attempts:     1,
+			wantDecision: healAct,
+		},
+		{
+			name:         "attempts at cap -> capped",
+			runningSince: now.Add(-5 * time.Minute),
+			lastAttempt:  now.Add(-2 * time.Minute),
+			attempts:     3,
+			wantDecision: healCapped,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, wait := decideHeal(now, tc.runningSince, tc.lastAttempt, tc.attempts, cfg)
+			if got != tc.wantDecision {
+				t.Errorf("decision=%d, want %d", got, tc.wantDecision)
+			}
+			if got == healWait && wait <= 0 {
+				t.Errorf("healWait should return a positive requeue delay, got %v", wait)
+			}
+		})
+	}
+}
+
+func TestReadHealState(t *testing.T) {
+	ts := time.Now().UTC().Truncate(time.Second)
+	cdnos := &cdnosv1.Cdnos{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				healAttemptsAnnotation:    "2",
+				healLastAttemptAnnotation: ts.Format(time.RFC3339),
+			},
+		},
+	}
+	attempts, last := readHealState(cdnos)
+	if attempts != 2 {
+		t.Errorf("attempts=%d, want 2", attempts)
+	}
+	if !last.Equal(ts) {
+		t.Errorf("lastAttempt=%v, want %v", last, ts)
+	}
+
+	empty, zero := readHealState(&cdnosv1.Cdnos{})
+	if empty != 0 || !zero.IsZero() {
+		t.Errorf("empty cdnos: attempts=%d last=%v, want 0 and zero", empty, zero)
+	}
+}
+
+// --- orchestration tests (fake client) ---
+
+func TestReconcileMeshnetHeal_RecreatesUnderWiredPod(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+	r, rec := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != r.MeshnetHeal.GracePeriod {
+		t.Errorf("RequeueAfter=%v, want %v", res.RequeueAfter, r.MeshnetHeal.GracePeriod)
+	}
+
+	// Pod should have been deleted.
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected pod to be deleted, got err=%v", err)
+	}
+
+	// Attempt count recorded on the Cdnos.
+	got := &cdnosv1.Cdnos{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get cdnos: %v", err)
+	}
+	if got.Annotations[healAttemptsAnnotation] != "1" {
+		t.Errorf("attempts annotation=%q, want 1", got.Annotations[healAttemptsAnnotation])
+	}
+	if got.Annotations[healLastAttemptAnnotation] == "" {
+		t.Errorf("last-attempt annotation not set")
+	}
+	assertEvent(t, rec, healReasonRecreate)
+}
+
+func TestReconcileMeshnetHeal_WiredPodClearsState(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	cdnos.Annotations = map[string]string{
+		healAttemptsAnnotation:    "2",
+		healLastAttemptAnnotation: time.Now().Format(time.RFC3339),
+	}
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pod must NOT be deleted.
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("wired pod should not be deleted, got err=%v", err)
+	}
+	got := &cdnosv1.Cdnos{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get cdnos: %v", err)
+	}
+	if _, ok := got.Annotations[healAttemptsAnnotation]; ok {
+		t.Errorf("heal state should have been cleared, annotations=%v", got.Annotations)
+	}
+}
+
+func TestReconcileMeshnetHeal_WithinGraceNoDelete(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-10*time.Second))
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Errorf("expected a positive requeue while within grace, got %v", res.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("pod within grace must not be deleted, got err=%v", err)
+	}
+}
+
+func TestReconcileMeshnetHeal_CapReachedWarns(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+	cdnos.Annotations = map[string]string{
+		healAttemptsAnnotation:    "3",
+		healLastAttemptAnnotation: time.Now().Add(-5 * time.Minute).Format(time.RFC3339),
+	}
+	r, rec := newReconciler(cdnos, pod, topo)
+
+	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Pod must NOT be deleted once the cap is hit.
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("capped pod must not be deleted, got err=%v", err)
+	}
+	got := &cdnosv1.Cdnos{}
+	_ = r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, got)
+	if got.Annotations[healCappedAnnotation] != "true" {
+		t.Errorf("capped annotation not set, annotations=%v", got.Annotations)
+	}
+	assertEvent(t, rec, healReasonCapped)
+}
+
+func TestReconcileMeshnetHeal_NotMeshnetPodNoop(t *testing.T) {
+	cdnos, pod, _ := fixtures("r0", "ns", 0, "", "", time.Now().Add(-5*time.Minute))
+	// No Topology object passed -> not a meshnet pod.
+	r, _ := newReconciler(cdnos, pod)
+
+	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("non-meshnet pod must not be deleted, got err=%v", err)
+	}
+}
+
+func TestReconcileMeshnetHeal_DisabledNoop(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+	r, _ := newReconciler(cdnos, pod, topo)
+	r.MeshnetHeal.Enabled = false
+
+	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("disabled feature must not delete pod, got err=%v", err)
+	}
+}
+
+func TestReconcileMeshnetHeal_PendingPodNoop(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+	pod.Status.Phase = corev1.PodPending
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("pending pod should not requeue, got %v", res.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("pending pod must not be deleted, got err=%v", err)
+	}
+}
+
+// --- helpers ---
+
+func newTopology(name, ns string, links []interface{}, netNs, srcIP string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(topologyGVK)
+	u.SetName(name)
+	u.SetNamespace(ns)
+	spec := map[string]interface{}{}
+	if links != nil {
+		spec["links"] = links
+	}
+	u.Object["spec"] = spec
+	status := map[string]interface{}{}
+	if netNs != "" {
+		status["net_ns"] = netNs
+	}
+	if srcIP != "" {
+		status["src_ip"] = srcIP
+	}
+	u.Object["status"] = status
+	return u
+}
+
+func fixtures(name, ns string, nLinks int, netNs, srcIP string, startedAt time.Time) (*cdnosv1.Cdnos, *corev1.Pod, *unstructured.Unstructured) {
+	cdnos := &cdnosv1.Cdnos{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       cdnosv1.CdnosSpec{InterfaceCount: nLinks},
+	}
+	start := metav1.NewTime(startedAt)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: corev1.PodStatus{
+			Phase:     corev1.PodRunning,
+			StartTime: &start,
+		},
+	}
+	var links []interface{}
+	for i := 0; i < nLinks; i++ {
+		links = append(links, map[string]interface{}{"local_intf": "eth" + strconv.Itoa(i+1)})
+	}
+	topo := newTopology(name, ns, links, netNs, srcIP)
+	return cdnos, pod, topo
+}
+
+func newReconciler(objs ...client.Object) (*CdnosReconciler, *record.FakeRecorder) {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = cdnosv1.AddToScheme(s)
+	// Register the meshnet Topology CR as unstructured so the fake client can
+	// track it without importing the meshnet module.
+	s.AddKnownTypeWithName(topologyGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(topologyGVK.GroupVersion().WithKind("TopologyList"), &unstructured.UnstructuredList{})
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	rec := record.NewFakeRecorder(10)
+	return &CdnosReconciler{
+		Client:      c,
+		APIReader:   c,
+		Scheme:      s,
+		Recorder:    rec,
+		MeshnetHeal: DefaultMeshnetHealConfig(),
+	}, rec
+}
+
+func assertEvent(t *testing.T, rec *record.FakeRecorder, reason string) {
+	t.Helper()
+	select {
+	case ev := <-rec.Events:
+		if !contains(ev, reason) {
+			t.Errorf("event %q does not contain reason %q", ev, reason)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("expected an event with reason %q, got none", reason)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/meshnet_heal_test.go
+++ b/internal/controller/meshnet_heal_test.go
@@ -294,8 +294,38 @@ func TestReconcileMeshnetHeal_DisabledNoop(t *testing.T) {
 	}
 }
 
-func TestReconcileMeshnetHeal_PendingPodNoop(t *testing.T) {
+// An under-wired pod stuck in Pending/Init (KNE init-wait loops forever
+// waiting for the missing interfaces) must heal after the grace period, since
+// it never reaches Running.
+func TestReconcileMeshnetHeal_PendingUnderWiredHealsAfterGrace(t *testing.T) {
 	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+	pod.Status.Phase = corev1.PodPending
+	r, rec := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != r.MeshnetHeal.GracePeriod {
+		t.Errorf("RequeueAfter=%v, want %v", res.RequeueAfter, r.MeshnetHeal.GracePeriod)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected under-wired Pending pod to be deleted, got err=%v", err)
+	}
+	got := &cdnosv1.Cdnos{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get cdnos: %v", err)
+	}
+	if got.Annotations[healAttemptsAnnotation] != "1" {
+		t.Errorf("attempts annotation=%q, want 1", got.Annotations[healAttemptsAnnotation])
+	}
+	assertEvent(t, rec, healReasonRecreate)
+}
+
+// An under-wired Pending pod still within the grace period must not be touched
+// (it may merely be starting up).
+func TestReconcileMeshnetHeal_PendingWithinGraceNoDelete(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-10*time.Second))
 	pod.Status.Phase = corev1.PodPending
 	r, _ := newReconciler(cdnos, pod, topo)
 
@@ -303,11 +333,48 @@ func TestReconcileMeshnetHeal_PendingPodNoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Errorf("pending pod should not requeue, got %v", res.RequeueAfter)
+	if res.RequeueAfter <= 0 {
+		t.Errorf("expected a positive requeue while within grace, got %v", res.RequeueAfter)
 	}
 	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
-		t.Errorf("pending pod must not be deleted, got err=%v", err)
+		t.Errorf("Pending pod within grace must not be deleted, got err=%v", err)
+	}
+}
+
+// A normally-starting pod (Pending/ContainerCreating) for which meshnet HAS
+// already run - status.net_ns set - must never be healed, even past the grace
+// period. This guards against deleting healthy pods that are simply still
+// starting their containers.
+func TestReconcileMeshnetHeal_PendingButWiredNoDelete(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 2, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	pod.Status.Phase = corev1.PodPending
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("wired (but still starting) pod must not be deleted, got err=%v", err)
+	}
+}
+
+// Terminal pods (Succeeded/Failed) are never healed.
+func TestReconcileMeshnetHeal_TerminalPodNoop(t *testing.T) {
+	for _, phase := range []corev1.PodPhase{corev1.PodSucceeded, corev1.PodFailed} {
+		cdnos, pod, topo := fixtures("r0", "ns", 2, "", "", time.Now().Add(-5*time.Minute))
+		pod.Status.Phase = phase
+		r, _ := newReconciler(cdnos, pod, topo)
+
+		res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+		if err != nil {
+			t.Fatalf("phase %s: unexpected error: %v", phase, err)
+		}
+		if res.RequeueAfter != 0 {
+			t.Errorf("phase %s: should not requeue, got %v", phase, res.RequeueAfter)
+		}
+		if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+			t.Errorf("phase %s: terminal pod must not be deleted, got err=%v", phase, err)
+		}
 	}
 }
 

--- a/manifest/controllers_cdnos_manifest.yaml
+++ b/manifest/controllers_cdnos_manifest.yaml
@@ -473,6 +473,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networkop.co.uk
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/manifest/controllers_cdnos_manifest.yaml
+++ b/manifest/controllers_cdnos_manifest.yaml
@@ -473,6 +473,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - networkop.co.uk
   resources:
   - topologies


### PR DESCRIPTION
## Problem (AR-65093)

On a freshly autoscaled node, an mcDNOS/Cdnos pod's CNI `ADD` can run **before**
meshnet's CNI conflist is installed/ready on that node. When that happens the
meshnet CNI plugin never runs for the pod, so the pod comes up with **only the
base CNI interface (`eth0`)** and is permanently missing its meshnet data
interfaces — stuck "Connected 1 of N" until the pod is recreated by hand.

## Why the taint-gate approach was insufficient on AKS

The intended fix was a node-initialization taint that meshnetd removes once its
conflist is installed (so pods can't schedule onto a not-yet-ready node). AKS
does **not** apply node-initialization taints to fresh cluster-autoscaler nodes,
so that gate never engages on the exact nodes we care about. We therefore keep
the fix inside our own component, independent of AKS platform features and the
autoscaler.

## Detection signal (the crux)

meshnet maintains a per-pod **`Topology` CR** (`networkop.co.uk/v1beta1`, named
after the pod). We read it as an **unstructured** object, so the controller takes
**no compile-time dependency** on the meshnet module.

- `spec.links` is the authoritative set of interfaces meshnet must wire.
- meshnet's CNI plugin calls `SetAlive` — which stamps `status.net_ns` /
  `status.src_ip` — at the **very start of its `ADD`, before it traverses any
  link** (`plugin/meshnet.go`: `SetAlive` is invoked immediately after computing
  the VTEP source, ahead of the per-link loop).

Therefore an **empty `status.net_ns`** on a pod whose `Topology` has
`spec.links` means *meshnet never ran for this pod* — exactly the new-node race.
Crucially, a pod that is merely waiting for slow peers **still has `net_ns`
set** (the plugin ran and recorded the pod alive, then skipped peers), so this
signal does **not** false-positive on normal wiring-in-progress.

The controller already knows the expected interface count
(`Cdnos.Spec.InterfaceCount`), but the `Topology` CR is the lower-coupling,
more authoritative signal and is what this PR keys off.

## Why this repo (cdnos-controller) and not meshnet

The heal action is **recreate the pod**, which is the cdnos-controller's native,
well-tested operation (it already deletes+recreates pods on spec change). The
meshnet-side alternative (re-wire interfaces in place) is strictly more complex
and risky, and would duplicate pod-lifecycle logic the controller already owns.
Reading one read-only CR per running meshnet pod is low coupling.

## Heal mechanism

Delete the under-wired pod. The normal reconcile path recreates it, so its CNI
`ADD` re-runs once meshnet is ready and meshnet wires it normally. (meshnet's
own readiness-retry fix makes the re-run reliable.)

## Guardrails (a buggy heal loop could mass-delete pods)

- **Grace period** (default `90s`) before acting, anchored on the pod's start
  time — never races a pod still legitimately wiring.
- **Bounded attempts** per pod (default `3`) with **backoff** (default `60s`),
  tracked via annotations on the `Cdnos` CR so the budget survives pod
  recreation. On success the accounting is cleared; after the cap a **Warning**
  event is emitted instead of looping forever.
- Acts only on **Running, non-terminating** pods, and **re-reads the pod from
  cache** so it never races a create / spec-change recreation.
- **Healthy (wired) pods always have `net_ns` set and are never touched** — the
  worst plausible misfire is one unnecessary recreate of a single pod, never a
  mass delete.
- Emits a clear **k8s Event + structured log** on each heal
  (`recreating under-wired Cdnos pod <ns>/<name>: 0/M meshnet interfaces wired
  (attempt n/max)`).
- **Gate-able**: `--meshnet-heal-enabled` (**default on**, because the race
  otherwise leaves pods permanently stuck and requiring manual recreation),
  plus `--meshnet-heal-grace`, `--meshnet-heal-max-attempts`,
  `--meshnet-heal-backoff`.
- Per-`Cdnos` reconciles are serialized by controller-runtime, so the
  read-modify-write of the heal-accounting annotations is concurrency-safe.

### Known limitation (safe by design)

If a node dies abruptly (CNI `DEL` never runs) and the pod is rescheduled, the
`Topology` status can retain stale non-empty `net_ns`, making the new pod look
"wired" — a **false negative** (we don't heal that rare case; it behaves as
today). This is intentional: we accept misses, never false-positive deletions of
healthy pods.

## Changes

- `internal/controller/meshnet_heal.go` — detection, decision core, heal + accounting.
- `internal/controller/cdnos_controller.go` — `Recorder` + `MeshnetHeal` fields,
  RBAC marker, call `reconcileMeshnetHeal` from `Reconcile`.
- `cmd/main.go` — flags + event recorder wiring.
- RBAC: `get;list;watch` on `topologies.networkop.co.uk` (kustomize `role.yaml`
  and the all-in-one install manifest).
- `internal/controller/meshnet_heal_test.go` — fake-client unit tests.

## Tests

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./internal/controller/ -run 'TestMeshnetWiring|TestDecideHeal|TestReadHealState|TestReconcileMeshnetHeal'` ✅
  (detection signal, decision core under grace/backoff/cap, recreate path,
  wired-pod clears state, within-grace no-op, cap warns, non-meshnet/disabled/
  pending no-ops). The pre-existing Ginkgo suite still requires envtest binaries
  (`make test`).

## Validation note

End-to-end validation needs a **cluster deploy + a fresh-node scale event**; the
target AKS cluster is currently stopped, so that has not been exercised here.
