### PR TITLE
manifest: bump cdnos-controller image to 1.9.0 (AR-65093)

### DIFF
--- a/config/manifests/manifest.yaml
+++ b/config/manifests/manifest.yaml
@@ -473,6 +473,21 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networkop.co.uk
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
@@ -666,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: public.ecr.aws/drivenets/cdnos-controller:1.8.0
+        image: public.ecr.aws/drivenets/cdnos-controller:1.9.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/controllers_cdnos_manifest.yaml
+++ b/manifest/controllers_cdnos_manifest.yaml
@@ -681,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: public.ecr.aws/drivenets/cdnos-controller:1.8.0
+        image: public.ecr.aws/drivenets/cdnos-controller:1.9.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Bumps the deployed controller image to `public.ecr.aws/drivenets/cdnos-controller:1.9.0` (the detect-and-heal build from #34) in both deploy manifests.

Also adds the missing `networkop.co.uk/topologies` (get/list/watch) and `core/events` (create/patch) RBAC rules to `config/manifests/manifest.yaml` so it matches `manifest/controllers_cdnos_manifest.yaml` (which #34 already updated). The two manifests are now identical.

Refs AR-65093. Follow-up to #34 (manifest bump only; main is PR-protected so this lands via PR).