### PR TITLE
Heal partially-wired meshnet pods, not just fully-unwired (AR-65093)

### DIFF
--- a/internal/controller/meshnet_heal.go
+++ b/internal/controller/meshnet_heal.go
@@ -34,26 +34,47 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// Detect-and-heal for the meshnet new-node wiring race (AR-65093).
+// Detect-and-heal for meshnet under-wiring (AR-65093).
 //
-// On a freshly autoscaled node, a Cdnos/mcDNOS pod's CNI ADD can run before
-// meshnet's CNI conflist is installed/ready on that node. When that happens the
-// meshnet CNI plugin never runs for the pod, so the pod comes up with only the
-// base CNI interface (eth0) and is permanently missing its meshnet data
-// interfaces until it is recreated.
+// On a freshly autoscaled node, a Cdnos/mcDNOS pod can come up missing some or
+// all of its meshnet data interfaces, and KNE's init-wait init container then
+// blocks the pod in Init:0/1 forever (it loops until every expected interface
+// is present). Two observed variants:
+//
+//   - Fully unwired (the new-node race): the pod's CNI ADD runs before meshnet's
+//     CNI conflist is installed/ready on the node, so the meshnet CNI plugin
+//     never runs and the pod has only eth0 (0 data interfaces).
+//   - Partially wired (dead/slow-peer deadlock): meshnet ran but could not wire
+//     every link because some peer pod was not alive yet, and that peer never
+//     comes up healthy - so a subset of interfaces is permanently missing
+//     (observed at 50-node scale: n35/n37 stuck at 2/4).
 //
 // Detection signal (low coupling, read-only): meshnet maintains a per-pod
 // Topology CR (networkop.co.uk/v1beta1, named after the pod). Its spec.links is
-// the authoritative set of interfaces meshnet must wire, and meshnet's CNI
-// plugin calls SetAlive - which stamps status.net_ns / status.src_ip - at the
-// very start of its ADD, before it traverses any link. Therefore an empty
-// status.net_ns on a pod whose Topology has spec.links means "meshnet never ran
-// for this pod", which is exactly the new-node race. A pod that is merely
-// waiting for slow peers still has net_ns set, so this signal does not
-// false-positive on normal wiring in progress.
+// the authoritative set of interfaces meshnet must wire, so expected =
+// len(spec.links). A pod is under-wired whenever fewer than expected interfaces
+// are actually present.
+//
+// "Actual wired" signal: we do NOT trust Topology status.skipped as a wired
+// count. status.skipped records links THIS pod skipped during its own CNI ADD
+// (peer not yet alive); meshnet never clears it once the peer later wires the
+// link from its side, so at scale most fully-healthy Running/Ready pods carry
+// stale skipped entries (some 4/4). Keying on skipped would recreate the whole
+// fleet. Instead we use KNE's init-wait init container as the ground-truth
+// interface counter: init-wait blocks precisely until all expected interfaces
+// exist, so a pod whose init containers have all completed (or that has reached
+// Running) is fully wired, and a pod still stuck in init past the grace period
+// is under-wired. status.net_ns / status.src_ip (stamped by meshnet's SetAlive
+// at the very start of CNI ADD) are kept only to label the variant in
+// logs/events: empty => meshnet never ran (fully unwired); set => meshnet ran
+// but did not finish (partial).
 //
 // Heal: delete the under-wired pod. The normal reconcile path recreates it, so
-// its CNI ADD re-runs once meshnet is ready and meshnet wires it normally.
+// its CNI ADD re-runs - once meshnet is ready and peers are up - and meshnet
+// wires it normally. Recreate is bounded (grace + attempt cap + backoff), so a
+// pod that is merely mid-wiring behind a transiently-slow peer is protected by
+// the grace period, and even an over-eager recreate is self-correcting and
+// capped rather than a recreate loop.
 
 const (
 	healAttemptsAnnotation    = "meshnet.heal.cdnos.dev.drivenets.net/attempts"
@@ -134,15 +155,58 @@ func decideHeal(now, runningSince, lastAttempt time.Time, attempts int, cfg Mesh
 }
 
 // meshnetWiring extracts, from a Topology CR, the number of links meshnet is
-// expected to wire and whether meshnet has marked the pod alive (i.e. its CNI
-// plugin ran). expected>0 && !wired is the AR-65093 under-wired signal.
-func meshnetWiring(topo *unstructured.Unstructured) (expected int, wired bool) {
+// expected to wire (expected = len(spec.links)) and whether meshnet has marked
+// the pod alive (ran), i.e. its CNI plugin started. ran is derived from
+// status.net_ns / status.src_ip, which meshnet's SetAlive stamps at the very
+// start of CNI ADD. ran distinguishes the fully-unwired variant (meshnet never
+// ran) from the partial variant (meshnet ran but did not finish) for
+// logging/events; the under-wired decision itself is made from the pod's
+// init-wait completion (see podWiringComplete), not from ran.
+func meshnetWiring(topo *unstructured.Unstructured) (expected int, ran bool) {
 	links, _, _ := unstructured.NestedSlice(topo.Object, "spec", "links")
 	expected = len(links)
 	netNs, _, _ := unstructured.NestedString(topo.Object, "status", "net_ns")
 	srcIP, _, _ := unstructured.NestedString(topo.Object, "status", "src_ip")
-	wired = netNs != "" && srcIP != ""
-	return expected, wired
+	ran = netNs != "" && srcIP != ""
+	return expected, ran
+}
+
+// podWiringComplete reports whether the pod has all of its expected meshnet
+// interfaces, using KNE's init-wait init container as the ground-truth
+// interface counter. init-wait blocks until every expected interface is
+// present, so:
+//   - a pod that has reached Running (or Succeeded) has necessarily passed
+//     init-wait and is fully wired; and
+//   - a still-initializing pod is fully wired only once all of its init
+//     containers have terminated successfully.
+//
+// A pod still in init (including one with no init-container status reported yet)
+// is treated as not-yet-complete; the grace period below prevents that from
+// false-positiving on pods that are merely still starting.
+func podWiringComplete(pod *corev1.Pod) bool {
+	switch pod.Status.Phase {
+	case corev1.PodRunning, corev1.PodSucceeded:
+		return true
+	}
+	if len(pod.Status.InitContainerStatuses) == 0 {
+		return false
+	}
+	for _, s := range pod.Status.InitContainerStatuses {
+		if s.State.Terminated == nil || s.State.Terminated.ExitCode != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// underWiredDesc returns a human-readable description of the under-wired
+// variant for logs/events. We cannot read the exact present-interface count
+// from the API, so we describe the variant rather than print a precise N/expected.
+func underWiredDesc(ran bool, expected int) string {
+	if !ran {
+		return fmt.Sprintf("meshnet never ran: 0/%d interfaces wired", expected)
+	}
+	return fmt.Sprintf("meshnet wiring incomplete: fewer than %d interfaces wired", expected)
 }
 
 // podRunningSince returns the time the pod's sandbox started, used as the
@@ -202,17 +266,20 @@ func (r *CdnosReconciler) reconcileMeshnetHeal(ctx context.Context, cdnos *cdnos
 		return ctrl.Result{}, err
 	}
 
-	expected, wired := meshnetWiring(topo)
+	expected, ran := meshnetWiring(topo)
 	if expected == 0 {
 		return ctrl.Result{}, nil
 	}
-	if wired {
-		// Healthy: clear any heal accounting so a future race on this Cdnos
-		// starts with a fresh budget.
+	if podWiringComplete(fresh) {
+		// Fully wired (init-wait passed): clear any heal accounting so a future
+		// under-wiring on this Cdnos starts with a fresh budget.
 		return ctrl.Result{}, r.clearHealState(ctx, cdnos)
 	}
 
-	// Under-wired: meshnet never ran for this pod incarnation.
+	// Under-wired: fewer than expected interfaces are present (init-wait is
+	// still blocking). ran labels the variant: false => meshnet never ran
+	// (fully unwired / new-node race); true => meshnet ran but did not finish
+	// wiring all links (partial / dead-peer deadlock).
 	now := time.Now()
 	attempts, lastAttempt := readHealState(cdnos)
 	decision, wait := decideHeal(now, podRunningSince(fresh), lastAttempt, attempts, r.MeshnetHeal)
@@ -223,8 +290,8 @@ func (r *CdnosReconciler) reconcileMeshnetHeal(ctx context.Context, cdnos *cdnos
 
 	case healCapped:
 		if cdnos.Annotations[healCappedAnnotation] != "true" {
-			msg := fmt.Sprintf("meshnet under-wired pod %s/%s not healed: 0/%d interfaces wired after %d attempts; manual intervention required",
-				fresh.Namespace, fresh.Name, expected, attempts)
+			msg := fmt.Sprintf("meshnet under-wired pod %s/%s not healed: %s after %d attempts; manual intervention required",
+				fresh.Namespace, fresh.Name, underWiredDesc(ran, expected), attempts)
 			log.Info(msg)
 			r.event(cdnos, corev1.EventTypeWarning, healReasonCapped, msg)
 			if err := r.patchHealAnnotations(ctx, cdnos, map[string]string{healCappedAnnotation: "true"}); err != nil {
@@ -242,8 +309,8 @@ func (r *CdnosReconciler) reconcileMeshnetHeal(ctx context.Context, cdnos *cdnos
 		}); err != nil {
 			return ctrl.Result{}, err
 		}
-		msg := fmt.Sprintf("recreating under-wired Cdnos pod %s/%s: 0/%d meshnet interfaces wired (attempt %d/%d)",
-			fresh.Namespace, fresh.Name, expected, attempts+1, r.MeshnetHeal.MaxAttempts)
+		msg := fmt.Sprintf("recreating under-wired Cdnos pod %s/%s: %s (attempt %d/%d)",
+			fresh.Namespace, fresh.Name, underWiredDesc(ran, expected), attempts+1, r.MeshnetHeal.MaxAttempts)
 		log.Info(msg)
 		r.event(cdnos, corev1.EventTypeNormal, healReasonRecreate, msg)
 		if err := r.Delete(ctx, fresh, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {

--- a/internal/controller/meshnet_heal_test.go
+++ b/internal/controller/meshnet_heal_test.go
@@ -206,6 +206,7 @@ func TestReconcileMeshnetHeal_RecreatesUnderWiredPod(t *testing.T) {
 
 func TestReconcileMeshnetHeal_WiredPodClearsState(t *testing.T) {
 	cdnos, pod, topo := fixtures("r0", "ns", 2, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	markPodWired(pod)
 	cdnos.Annotations = map[string]string{
 		healAttemptsAnnotation:    "2",
 		healLastAttemptAnnotation: time.Now().Format(time.RFC3339),
@@ -341,13 +342,20 @@ func TestReconcileMeshnetHeal_PendingWithinGraceNoDelete(t *testing.T) {
 	}
 }
 
-// A normally-starting pod (Pending/ContainerCreating) for which meshnet HAS
-// already run - status.net_ns set - must never be healed, even past the grace
-// period. This guards against deleting healthy pods that are simply still
-// starting their containers.
+// A normally-starting pod that is still Pending (e.g. pulling its main
+// container image) but whose init-wait has already completed - all expected
+// interfaces are present - must never be healed, even past the grace period.
+// This guards against deleting healthy pods that are simply still starting
+// their containers.
 func TestReconcileMeshnetHeal_PendingButWiredNoDelete(t *testing.T) {
 	cdnos, pod, topo := fixtures("r0", "ns", 2, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	// init-wait completed (all interfaces wired) but the pod has not reached
+	// Running yet because the main container is still starting.
 	pod.Status.Phase = corev1.PodPending
+	pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "init",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}},
+	}}
 	r, _ := newReconciler(cdnos, pod, topo)
 
 	if _, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod); err != nil {
@@ -378,6 +386,97 @@ func TestReconcileMeshnetHeal_TerminalPodNoop(t *testing.T) {
 	}
 }
 
+// A PARTIALLY-wired pod (meshnet ran - net_ns set - but did not finish wiring
+// every link, so init-wait is still blocking) must heal after the grace
+// period. This is the AR-65093 50-node-scale case (n35/n37 stuck at 2/4): the
+// old net_ns-only signal treated it as healthy and never recreated it.
+func TestReconcileMeshnetHeal_PartialWiredHealsAfterGrace(t *testing.T) {
+	// net_ns + src_ip set => meshnet ran; pod still Pending with init-wait
+	// running => fewer than expected interfaces are present.
+	cdnos, pod, topo := fixtures("r0", "ns", 4, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	r, rec := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != r.MeshnetHeal.GracePeriod {
+		t.Errorf("RequeueAfter=%v, want %v", res.RequeueAfter, r.MeshnetHeal.GracePeriod)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected partially-wired pod to be deleted, got err=%v", err)
+	}
+	got := &cdnosv1.Cdnos{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, got); err != nil {
+		t.Fatalf("get cdnos: %v", err)
+	}
+	if got.Annotations[healAttemptsAnnotation] != "1" {
+		t.Errorf("attempts annotation=%q, want 1", got.Annotations[healAttemptsAnnotation])
+	}
+	assertEvent(t, rec, healReasonRecreate)
+}
+
+// A partially-wired pod still within the grace period must not be touched: it
+// may merely be wiring behind a transiently-slow peer.
+func TestReconcileMeshnetHeal_PartialWithinGraceSkip(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 4, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-10*time.Second))
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Errorf("expected a positive requeue while within grace, got %v", res.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("partially-wired pod within grace must not be deleted, got err=%v", err)
+	}
+}
+
+// A fully-wired pod (init-wait passed) must be a no-op even though its Topology
+// may still carry stale status.skipped entries (which is why skipped is not
+// used as the wired signal).
+func TestReconcileMeshnetHeal_FullyWiredSkip(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 4, "/proc/1/ns/net", "10.0.0.1", time.Now().Add(-5*time.Minute))
+	markPodWired(pod)
+	// Stale skipped entries on an otherwise fully-wired pod must not trigger a heal.
+	_ = unstructured.SetNestedSlice(topo.Object, []interface{}{
+		map[string]interface{}{"link_id": int64(1), "pod_name": "peer"},
+		map[string]interface{}{"link_id": int64(2), "pod_name": "peer"},
+	}, "status", "skipped")
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("fully-wired pod should not requeue, got %v", res.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("fully-wired pod must not be deleted, got err=%v", err)
+	}
+}
+
+// A pod whose Topology has no links (expected == 0) is not a wired meshnet pod
+// and must be ignored even if it is stuck in init.
+func TestReconcileMeshnetHeal_NoLinkSkip(t *testing.T) {
+	cdnos, pod, topo := fixtures("r0", "ns", 0, "", "", time.Now().Add(-5*time.Minute))
+	r, _ := newReconciler(cdnos, pod, topo)
+
+	res, err := r.reconcileMeshnetHeal(context.Background(), cdnos, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("no-link pod should not requeue, got %v", res.RequeueAfter)
+	}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "r0", Namespace: "ns"}, &corev1.Pod{}); err != nil {
+		t.Errorf("no-link pod must not be deleted, got err=%v", err)
+	}
+}
+
 // --- helpers ---
 
 func newTopology(name, ns string, links []interface{}, netNs, srcIP string) *unstructured.Unstructured {
@@ -401,6 +500,10 @@ func newTopology(name, ns string, links []interface{}, netNs, srcIP string) *uns
 	return u
 }
 
+// fixtures builds a Cdnos, an under-wired pod, and its Topology. By default the
+// pod is modeled as under-wired: Pending with KNE's init-wait init container
+// still Running (so podWiringComplete is false), which matches a pod stuck in
+// Init:0/1. Tests that need a fully-wired pod call markPodWired.
 func fixtures(name, ns string, nLinks int, netNs, srcIP string, startedAt time.Time) (*cdnosv1.Cdnos, *corev1.Pod, *unstructured.Unstructured) {
 	cdnos := &cdnosv1.Cdnos{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -409,9 +512,14 @@ func fixtures(name, ns string, nLinks int, netNs, srcIP string, startedAt time.T
 	start := metav1.NewTime(startedAt)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       corev1.PodSpec{InitContainers: []corev1.Container{{Name: "init"}}},
 		Status: corev1.PodStatus{
-			Phase:     corev1.PodRunning,
+			Phase:     corev1.PodPending,
 			StartTime: &start,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "init",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
 		},
 	}
 	var links []interface{}
@@ -420,6 +528,16 @@ func fixtures(name, ns string, nLinks int, netNs, srcIP string, startedAt time.T
 	}
 	topo := newTopology(name, ns, links, netNs, srcIP)
 	return cdnos, pod, topo
+}
+
+// markPodWired marks the pod as fully wired (init-wait passed): it has reached
+// Running with its init container terminated successfully.
+func markPodWired(pod *corev1.Pod) {
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "init",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}},
+	}}
 }
 
 func newReconciler(objs ...client.Object) (*CdnosReconciler, *record.FakeRecorder) {


### PR DESCRIPTION
## Summary

GAP 1 follow-up to the detect-and-heal that shipped in 1.9.0 (#34). That heal only recreated pods meshnet **never** wired (`status.net_ns` empty). At 50-node scale, pods that came up **partially** wired (e.g. `n35`/`n37` stuck at 2/4 because a peer pod never came up healthy) have `net_ns` set, so the old signal treated them as healthy — they stayed stuck in `Init:0/1` forever (KNE `init-wait` blocks until ALL interfaces are present).

This broadens the trigger from *"meshnet never ran"* to **under-wired = fewer than expected interfaces present**, while keeping every existing guardrail.

## Detection-signal choice

- **Rejected `Topology status.skipped` as a wired count.** Investigated the live 50-node cluster: meshnet records `skipped` for links this pod couldn't wire during its own CNI ADD (peer not yet alive) and **never clears it** once the peer wires the link from its side. Most fully-healthy `Running`/`Ready` pods carry stale `skipped` entries (some 4/4). Keying on `skipped` would recreate ~30 healthy pods.
- **Chosen: KNE `init-wait` init-container completion as the ground-truth interface counter.** `init-wait` blocks precisely until all expected interfaces exist, so a pod that reached `Running` (or whose init containers all terminated successfully) is fully wired; one still stuck in init past the grace period is under-wired. `expected = len(spec.links)` still comes from the Topology CR.
- `status.net_ns`/`src_ip` are kept only to **label the variant** in logs/events (never-ran vs partial), not for the decision.

### Validated read-only against the live stuck cluster

Replaying the exact decision logic over the live `sitea` pods + Topology CRs:

- **Would heal:** `n35` (partial, 2/4), `n37` (partial, 2/4), `n36` (fully-unwired, never ran) — exactly the 3 stuck pods.
- **No-op:** all 47 other pods (fully wired), despite many carrying stale `skipped`. Zero healthy `Running` pods flagged.

## Guardrails (unchanged)

90s grace, 3-attempt cap + backoff, terminating/terminal pods excluded, feature gate (`--meshnet-heal-enabled`). Fully-wired pod (`init-wait` passed) is a no-op; no-link pod (`expected == 0`) is ignored. Recreate stays bounded and self-correcting, so a pod merely wiring behind a transiently-slow peer is protected by the grace period.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests: partial-wired-heals-after-grace, partial-but-within-grace-skip, fully-wired-skip (with stale `status.skipped` present), no-link-skip
- [x] Existing tests updated to model wiring state via `init-wait` completion
- [ ] Coordinated validation deploy on the scale cluster (owner-driven; this PR does **not** redeploy)
