### PR TITLE
Pin cdnos-controller image to released 1.9.1 [AR-65093]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # CDNOS Image URL to use to test CDNOS CRD Deployment
 CDNOS_IMG ?= registry.dev.drivenets.net/devops/cdnos_pr_61596:19.1.0.1_priv.61596.59ad5662f25a3760114008c0e51c2ef1b583ae7e
 # Image URL to use all building/pushing image targets
-CONTROLLER_IMG ?= public.ecr.aws/drivenets/cdnos-controller:1.8.0
+CONTROLLER_IMG ?= public.ecr.aws/drivenets/cdnos-controller:1.9.1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: public.ecr.aws/drivenets/cdnos-controller
-  newTag: 1.8.0
+  newName: dapdev.azurecr.io/cdnos-controller
+  newTag: detect-and-heal-partial-bcb3cdc

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: dapdev.azurecr.io/cdnos-controller
-  newTag: detect-and-heal-partial-bcb3cdc
+  newName: public.ecr.aws/drivenets/cdnos-controller
+  newTag: 1.9.1

--- a/config/manifests/manifest.yaml
+++ b/config/manifests/manifest.yaml
@@ -434,6 +434,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - secrets
   - serviceaccounts
@@ -472,13 +479,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - networkop.co.uk
   resources:
@@ -681,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: dapdev.azurecr.io/cdnos-controller:detect-and-heal-partial-bcb3cdc
+        image: public.ecr.aws/drivenets/cdnos-controller:1.9.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manifests/manifest.yaml
+++ b/config/manifests/manifest.yaml
@@ -681,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: public.ecr.aws/drivenets/cdnos-controller:1.9.0
+        image: dapdev.azurecr.io/cdnos-controller:detect-and-heal-partial-bcb3cdc
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - secrets
   - serviceaccounts
@@ -45,13 +52,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - networkop.co.uk
   resources:

--- a/manifest/controllers_cdnos_manifest.yaml
+++ b/manifest/controllers_cdnos_manifest.yaml
@@ -434,6 +434,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - secrets
   - serviceaccounts
@@ -472,13 +479,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - networkop.co.uk
   resources:
@@ -681,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: dapdev.azurecr.io/cdnos-controller:detect-and-heal-partial-bcb3cdc
+        image: public.ecr.aws/drivenets/cdnos-controller:1.9.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/controllers_cdnos_manifest.yaml
+++ b/manifest/controllers_cdnos_manifest.yaml
@@ -681,7 +681,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: public.ecr.aws/drivenets/cdnos-controller:1.9.0
+        image: dapdev.azurecr.io/cdnos-controller:detect-and-heal-partial-bcb3cdc
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary
Pins the cdnos-controller Deployment to the **released** image `public.ecr.aws/drivenets/cdnos-controller:1.9.1` for the upcoming (currently stopped) cluster resume. No deploy is performed by this PR.

`1.9.1` is a patch bump over the previous release `1.9.0`. It is built from `main` HEAD (`27575b4`), which includes the merged PR #36 (`Heal partially-wired meshnet pods, not just fully-unwired ones (AR-65093)`, `bcb3cdc`) on top of the `1.9.0` baseline.

- Image: `public.ecr.aws/drivenets/cdnos-controller:1.9.1`
- Digest: `sha256:7f552da94e15a4cf9f68d16ff201307784a49fa5546cd44fdf872f63d1f61e18`
- Registry: the canonical public-ECR alias used by `1.8.0`/`1.9.0` (replaces the earlier `dapdev` dev tag).

## Changes
- `Makefile`: `CONTROLLER_IMG` → `public.ecr.aws/drivenets/cdnos-controller:1.9.1`.
- `config/manager/kustomization.yaml`: `newName` → `public.ecr.aws/drivenets/cdnos-controller`, `newTag` → `1.9.1`.
- `config/manifests/manifest.yaml` + `manifest/controllers_cdnos_manifest.yaml`: regenerated via `make generate-manifest`; controller `image` → `1.9.1`. `make verify-manifest` passes.
- `config/rbac/role.yaml`: the pinned `controller-gen` v0.20.0 reorders the existing `events` RBAC rule (moved earlier in the list). This is a no-op reordering — identical rules — and is a side effect of running the documented manifest-gen step.

## Notes
- The previous tags in `kustomization.yaml` (`1.8.0`) and the generated manifest (`1.9.0`) were inconsistent on `main`; regenerating from a single `1.9.1` `kustomization` source now makes all of them consistent.
- The image was built on the devvm (linux/amd64, native) from `main` HEAD and pushed to the canonical public-ECR registry; tag + digest verified in the registry before pinning.

## Test plan
- [ ] Confirm image ref resolves from the deployment environment (pull `public.ecr.aws/drivenets/cdnos-controller:1.9.1`).
- [ ] Apply on cluster resume (not part of this PR).
